### PR TITLE
fix: updated components versions and dashboard metrics name fixes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
     command: "java -javaagent:/opentelemetry-javaagent.jar -jar /app.jar"
 
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.81.0
+    image: otel/opentelemetry-collector-contrib:0.87.0
     command:
       - "--config=/conf/config.yaml"
     volumes:
@@ -43,13 +43,13 @@ services:
       - tempo
 
   tempo:
-    image: grafana/tempo:2.1.1
+    image: grafana/tempo:2.2.3
     command: [ "--target=all", "--storage.trace.backend=local", "--storage.trace.local.path=/var/tempo", "--auth.enabled=false" ]
     ports:
       - "14250:14250"
 
   prometheus:
-    image: prom/prometheus:v2.45.0
+    image: prom/prometheus:v2.47.2
     ports:
       - "9090:9090"
     volumes:
@@ -58,7 +58,7 @@ services:
       - --config.file=/workspace/prometheus.yml
 
   grafana:
-    image: grafana/grafana:10.0.2
+    image: grafana/grafana:10.1.4
     ports:
       - "3000:3000"
     volumes:

--- a/etc/dashboards/OpenTelemetry-APM.json
+++ b/etc/dashboards/OpenTelemetry-APM.json
@@ -18,7 +18,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -69,7 +68,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -77,7 +76,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(service_name)",
+          "expr": "sum(duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(service_name)",
           "instant": false,
           "legendFormat": "{{label_name}}",
           "range": true,
@@ -132,7 +131,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -141,7 +140,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^2.*\", http_route=~\"$route\"}) by(http_status_code)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^2.*\", http_route=~\"$route\"}) by(http_status_code)",
           "format": "time_series",
           "instant": false,
           "legendFormat": "Http Status 2XX",
@@ -155,7 +154,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^3.*\", http_route=~\"$route\"}) by(http_status_code)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^3.*\", http_route=~\"$route\"}) by(http_status_code)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -170,7 +169,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^4.*\", http_route=~\"$route\"}) by(http_status_code)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^4.*\", http_route=~\"$route\"}) by(http_status_code)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -185,7 +184,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^5.*\", http_route=~\"$route\"}) by(http_status_code)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_status_code=~\"^5.*\", http_route=~\"$route\"}) by(http_status_code)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -259,7 +258,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(span_name)",
+          "expr": "sum(duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(span_name)",
           "instant": false,
           "legendFormat": "{{label_name}}",
           "range": true,
@@ -332,7 +331,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_sum{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(span_name)",
+          "expr": "sum(duration_milliseconds_sum{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}) by(span_name)",
           "instant": true,
           "legendFormat": "{{label_name}}",
           "range": false,
@@ -386,7 +385,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -394,7 +393,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}[3m])*60)",
+          "expr": "sum(rate(duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}[3m])*60)",
           "hide": false,
           "instant": false,
           "range": true,
@@ -452,7 +451,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -460,7 +459,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code=~\"5.*|\", http_route=~\"$route\"})/sum(duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"})",
+          "expr": "sum(duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code=~\"5.*|\", http_route=~\"$route\"})/sum(duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"})",
           "instant": false,
           "range": true,
           "refId": "A"
@@ -494,6 +493,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -555,7 +555,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(rate(duration_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_route=~\"$route\"}[3m])*60)  by(span_name)",
+          "expr": "sum(rate(duration_milliseconds_count{service_name=\"$app\", span_kind=\"SPAN_KIND_SERVER\", http_route=~\"$route\"}[3m])*60)  by(span_name)",
           "hide": false,
           "instant": false,
           "legendFormat": "{{label_name}}",
@@ -591,6 +591,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineWidth": 1,
             "pointSize": 5,
@@ -651,7 +652,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(duration_bucket{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}[3m])) by (le, span_name))",
+          "expr": "histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_route=~\"$route\"}[3m])) by (le, span_name))",
           "instant": false,
           "legendFormat": "{{label_name}}",
           "range": true,
@@ -712,7 +713,7 @@
         "showUnfilled": true,
         "valueMode": "color"
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -721,7 +722,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sort_desc(duration_sum{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code!=\"\", http_route=~\"$route\"} / duration_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code!=\"\", http_route=~\"$route\"})",
+          "expr": "sort_desc(duration_milliseconds_sum{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code!=\"\", http_route=~\"$route\"} / duration_milliseconds_count{span_kind=\"SPAN_KIND_SERVER\", service_name=\"$app\", http_status_code!=\"\", http_route=~\"$route\"})",
           "instant": true,
           "legendFormat": "[{{http_status_code}}] {{span_name}}",
           "range": false,
@@ -889,7 +890,7 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "10.0.2",
+      "pluginVersion": "10.1.4",
       "targets": [
         {
           "datasource": {
@@ -898,7 +899,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])*60) by(service_name, http_method, http_route)",
+          "expr": "sum(rate(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])*60) by(service_name, http_method, http_route)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -912,7 +913,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(rate(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])*60) by(service_name, http_method, http_route)",
+          "expr": "sum(rate(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])*60) by(service_name, http_method, http_route)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -925,7 +926,7 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum(rate(duration_bucket{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])) by (le, service_name, http_method, http_route))",
+          "expr": "histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])) by (le, service_name, http_method, http_route))",
           "hide": false,
           "instant": false,
           "range": true,
@@ -938,7 +939,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "histogram_quantile(0.95, sum(rate(duration_bucket{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])) by (le, service_name, http_method, http_route))",
+          "expr": "histogram_quantile(0.95, sum(rate(duration_milliseconds_bucket{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}[3m])) by (le, service_name, http_method, http_route))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -952,7 +953,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\", http_status_code!~\"2.*|3.*\"}) by(service_name, http_method, http_route) / sum(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}) by(service_name, http_method, http_route)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\", http_status_code!~\"2.*|3.*\"}) by(service_name, http_method, http_route) / sum(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}) by(service_name, http_method, http_route)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -966,7 +967,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\", http_status_code!~\"2.*|3.*\"}) by(service_name, http_method, http_route) / sum(duration_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}) by(service_name, http_method, http_route)",
+          "expr": "sum(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\", http_status_code!~\"2.*|3.*\"}) by(service_name, http_method, http_route) / sum(duration_milliseconds_count{service_name=\"$app\", http_route=~\"$route\", span_kind=\"SPAN_KIND_SERVER\"}) by(service_name, http_method, http_route)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1031,9 +1032,10 @@
     "list": [
       {
         "current": {
+          "isNone": true,
           "selected": false,
-          "text": "fastapi",
-          "value": "fastapi"
+          "text": "None",
+          "value": ""
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
It was updated the docker images version for otel-collector, tempo, prometheus and grafana to the latest release, and minor fixes on metrics names on dashboard.

